### PR TITLE
Cleaning up clean()

### DIFF
--- a/aEye/auxiliary.py
+++ b/aEye/auxiliary.py
@@ -251,12 +251,8 @@ class Aux:
                     os.remove(f'{path}/{video}')
         except Exception as e:
             print(e)
-            pass
-
-        try:
+        finally:
             shutil.rmtree(path)
-        except Exception as e:
-            print(e)
 
 
         logging.info("successfully remove the temp folder from local machine")

--- a/aEye/auxiliary.py
+++ b/aEye/auxiliary.py
@@ -3,6 +3,7 @@ Module contains the Aux class that handles the loading and uploading of videos. 
 
 """
 
+import shutil
 from aEye.video import Video
 import boto3
 import tempfile
@@ -244,11 +245,19 @@ class Aux:
         if path is None:
             path = self._local_path if self._local_path else self._temp_folder
 
-        for (path, _, files) in os.walk(path, topdown=True):
-            for video in files:
-                os.remove(f'{path}/{video}')
+        try:
+            for (path, _, files) in os.walk(path, topdown=True):
+                for video in files:
+                    os.remove(f'{path}/{video}')
+        except Exception as e:
+            print(e)
+            pass
 
-        os.rmdir(path)
+        try:
+            shutil.rmtree(path)
+        except Exception as e:
+            print(e)
+
 
         logging.info("successfully remove the temp folder from local machine")
 


### PR DESCRIPTION
# Intro

Modified implementation of Aux.clean() to ensure that entire temp directory hierarchy is successfully deleted.

# Modifications

- Aux.clean() was modified to implement ```shutil.rmtree(path)``` instead of ```os.rmdir(path)```; this implementation ensure that the rooth of ***path***, all child directories, and all child files are deleted when called